### PR TITLE
Makefile to use arduino-cli

### DIFF
--- a/RAK10701-P-L.v1.0.6/Makefile
+++ b/RAK10701-P-L.v1.0.6/Makefile
@@ -1,0 +1,26 @@
+.PHONY:
+
+init:
+	
+	# Board
+	arduino-cli config init &2>/dev/null
+	sleep 1
+	
+	# Core
+	arduino-cli config add board_manager.additional_urls https://raw.githubusercontent.com/RAKWireless/RAKwireless-Arduino-BSP-Index/main/package_rakwireless.com_rui_index.json
+	arduino-cli update
+	arduino-cli core install rak_rui:nrf52
+	
+	# Libraries
+	arduino-cli config set library.enable_unsafe_install true
+	arduino-cli lib install --zip-path ../Lib_Used/*.zip 
+
+	# hack for linux/mac machines
+	[ ! -d src ] && ln -s Src src
+
+build:
+	arduino-cli compile --fqbn rak_rui:nrf52:WisCoreRAK4631Board .
+
+upload:
+	arduino-cli upload -p /dev/ttyACM0 --fqbn rak_rui:nrf52:WisCoreRAK4631Board .
+


### PR DESCRIPTION
Since there is no support on PlatformIO for RUI cores yet, using the CLI to build this project is only possible with arduino-cli. This Makefile exposes 3 main methods to init(ialize), build and upload the code to the device using arduino-cli.
The `init` method installs all required dependencies (core and libraries from the zipped ones). 
`arduino-cli` has to be preinstalled (check https://arduino.github.io/arduino-cli/0.33/).